### PR TITLE
administrative access policy

### DIFF
--- a/s3/standard-bucket.yaml
+++ b/s3/standard-bucket.yaml
@@ -45,6 +45,9 @@ Parameters:
     Type: String
     AllowedPattern: "([a-z0-9][a-z0-9-]{1,61}[a-z0-9])?"
     Description: Input bucket name if saving access logs
+  AdministrativeRoleName:
+    Type: String
+    Description: Name of administrative role
 
 # ---------------------------- Conditions
 Conditions:
@@ -147,17 +150,19 @@ Resources:
             Resource: !GetAtt StandardBucket.Arn
           - Sid: Deny-changing-bucket-permission
             Effect: Deny
-            NotPrincipal:
-              AWS: !Sub arn:aws:iam::${AWS::AccountId}:role/OrganizationAccountAccessRole
+            Principal: '*'
             Action:
               - s3:DeleteBucketPolicy
               - s3:PutBucketPolicy
               - s3:PutBucketPublicAccessBlock
             Resource: !GetAtt StandardBucket.Arn
+            Condition:
+              StringNotEquals: 
+                'aws:PrincipalARN': !Sub arn:aws:iam::${AWS::AccountId}:role/${AdministrativeRoleName}
           - Sid: Allow-oraganization-to-change-bucket-permission
             Effect: Allow
             Principal:
-              AWS: !Sub arn:aws:iam::${AWS::AccountId}:role/OrganizationAccountAccessRole
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:role/${AdministrativeRoleName}
             Action:
               - s3:DeleteBucketPolicy
               - s3:PutBucketPolicy
@@ -285,7 +290,7 @@ Resources:
             Effect: Allow
             Principal:
               AWS:
-                - !Sub arn:aws:iam::${AWS::AccountId}:role/OrganizationAccountAccessRole
+                - !Sub arn:aws:iam::${AWS::AccountId}:role/${AdministrativeRoleName}
             Action:
               - kms:Create*
               - kms:Describe*


### PR DESCRIPTION
Issue #34 
Stop using `NotPrincipal `and use `aws:PrincipalARN` in Condition.
https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html#condition-keys-principalarn

Issue #35 
Add administrative roles to parameters.
