### PR TITLE
#22 Add: Secg ADFS Cerrtificate Authentication

### DIFF
--- a/networks/create-vpc/create-securitygroup.yaml
+++ b/networks/create-vpc/create-securitygroup.yaml
@@ -702,6 +702,11 @@ Resources:
           FromPort: 443
           ToPort: 443
           CidrIp: !Ref CorpNetworkCidr
+        - Description: ADFS Certificate Authentication
+          IpProtocol: tcp
+          FromPort: 49443
+          ToPort: 49443
+          CidrIp: !Ref CorpNetworkCidr
   AllowInWSUS:
     Type: AWS::EC2::SecurityGroup
     Properties:


### PR DESCRIPTION
ADFS Certificate Authentication port (49443) is now allowed in the security group for ADFS.

issue #22 